### PR TITLE
Chore: bump polkadot parachain and clients versions

### DIFF
--- a/configs/interlay-services.yml
+++ b/configs/interlay-services.yml
@@ -52,7 +52,7 @@
     ports:
       - '3002:3002'
   oracle:
-    image: docker.io/interlayhq/interbtc-clients:oracle-parachain-metadata-interlay-testnet-1-17-0
+    image: docker.io/interlayhq/interbtc-clients:oracle-parachain-metadata-interlay-testnet-1.17.0
     command:
       - /bin/sh
       - -c
@@ -67,7 +67,7 @@
     environment:
       RUST_LOG: info
   vault_1:
-    image: interlayhq/interbtc-clients:vault-parachain-metadata-interlay-testnet-1-17-0
+    image: interlayhq/interbtc-clients:vault-parachain-metadata-interlay-testnet-1.17.0
     command:
       - /bin/sh
       - -c
@@ -85,7 +85,7 @@
       BITCOIN_RPC_PASS: rpcpassword
       RUST_LOG: info
   vault_2:
-    image: 'interlayhq/interbtc-clients:vault-parachain-metadata-interlay-testnet-1-17-0'
+    image: 'interlayhq/interbtc-clients:vault-parachain-metadata-interlay-testnet-1.17.0'
     command:
       - /bin/sh
       - -c
@@ -100,7 +100,7 @@
     environment:
       <<: *client-env
   vault_3:
-    image: 'interlayhq/interbtc-clients:vault-parachain-metadata-interlay-testnet-1-17-0'
+    image: 'interlayhq/interbtc-clients:vault-parachain-metadata-interlay-testnet-1.17.0'
     command:
       - /bin/sh
       - -c
@@ -115,7 +115,7 @@
     environment:
       <<: *client-env
   vault_to_liquidate:
-    image: 'interlayhq/interbtc-clients:vault-parachain-metadata-interlay-testnet-1-17-0'
+    image: 'interlayhq/interbtc-clients:vault-parachain-metadata-interlay-testnet-1.17.0'
     command:
       - /bin/sh
       - -c
@@ -130,7 +130,7 @@
     environment:
       <<: *client-env
   vault_to_ban:
-    image: 'interlayhq/interbtc-clients:vault-parachain-metadata-interlay-testnet-1-17-0'
+    image: 'interlayhq/interbtc-clients:vault-parachain-metadata-interlay-testnet-1.17.0'
     command:
       - /bin/sh
       - -c

--- a/configs/interlay-services.yml
+++ b/configs/interlay-services.yml
@@ -57,7 +57,7 @@
       - /bin/sh
       - -c
       - |
-        oracle-parachain-metadata-interlay-testnet \
+        /usr/local/bin/oracle \
         --keyring charlie \
         --btc-parachain-url 'ws://parachain-2000-0:9944' \
         --currency-id DOT=230 \
@@ -78,7 +78,7 @@
         # sleep for 30s to wait for bitcoin to create the Charlie wallet
         # and also to ensure that the issue period and redeem period are set
         sleep 30
-        vault-parachain-metadata-interlay-testnet --keyfile="keyfile.json" --keyname="vault_1" --auto-register=DOT=10000000000000 --btc-parachain-url 'ws://parachain-2000-0:9944'
+        /usr/local/bin/vault --keyfile="keyfile.json" --keyname="vault_1" --auto-register=DOT=10000000000000 --btc-parachain-url 'ws://parachain-2000-0:9944'
     environment: &client-env
       BITCOIN_RPC_URL: http://bitcoind:18443
       BITCOIN_RPC_USER: rpcuser
@@ -96,7 +96,7 @@
         # sleep for 30s to wait for bitcoin to create the Dave wallet
         # and also to ensure that the issue period and redeem period are set
         sleep 30
-        vault-parachain-metadata-interlay-testnet --keyfile="keyfile.json" --keyname=vault_2 --auto-register=DOT=10000000000000 --no-issue-execution --btc-parachain-url 'ws://parachain-2000-0:9944'
+        /usr/local/bin/vault --keyfile="keyfile.json" --keyname=vault_2 --auto-register=DOT=10000000000000 --no-issue-execution --btc-parachain-url 'ws://parachain-2000-0:9944'
     environment:
       <<: *client-env
   vault_3:
@@ -111,7 +111,7 @@
         # sleep for 30s to wait for bitcoin to create the Eve wallet
         # and also to ensure that the issue period and redeem period are set
         sleep 30
-        vault-parachain-metadata-interlay-testnet --keyfile="keyfile.json" --keyname=vault_3 --auto-register=DOT=10000000000000 --no-issue-execution --btc-parachain-url 'ws://parachain-2000-0:9944'
+        /usr/local/bin/vault --keyfile="keyfile.json" --keyname=vault_3 --auto-register=DOT=10000000000000 --no-issue-execution --btc-parachain-url 'ws://parachain-2000-0:9944'
     environment:
       <<: *client-env
   vault_to_liquidate:
@@ -126,7 +126,7 @@
         # sleep for 30s to wait for bitcoin to create the Ferdie wallet
         # and also to ensure that the issue period and redeem period are set
         sleep 30
-        vault-parachain-metadata-interlay-testnet --keyfile="keyfile.json" --keyname=vault_to_liquidate --auto-register=DOT=10000000000000 --btc-parachain-url 'ws://parachain-2000-0:9944'
+        /usr/local/bin/vault --keyfile="keyfile.json" --keyname=vault_to_liquidate --auto-register=DOT=10000000000000 --btc-parachain-url 'ws://parachain-2000-0:9944'
     environment:
       <<: *client-env
   vault_to_ban:
@@ -141,6 +141,6 @@
         # sleep for 30s to wait for bitcoin to create the Ferdie wallet
         # and also to ensure that the issue period and redeem period are set
         sleep 30
-        vault-parachain-metadata-interlay-testnet --keyfile="keyfile.json" --keyname=vault_to_ban --auto-register=DOT=10000000000000 --btc-parachain-url 'ws://parachain-2000-0:9944'
+        /usr/local/bin/vault --keyfile="keyfile.json" --keyname=vault_to_ban --auto-register=DOT=10000000000000 --btc-parachain-url 'ws://parachain-2000-0:9944'
     environment:
       <<: *client-env

--- a/configs/interlay-services.yml
+++ b/configs/interlay-services.yml
@@ -52,7 +52,7 @@
     ports:
       - '3002:3002'
   oracle:
-    image: docker.io/interlayhq/interbtc-clients:oracle-parachain-metadata-interlay-testnet-1-16-0
+    image: docker.io/interlayhq/interbtc-clients:oracle-parachain-metadata-interlay-testnet-1-17-0
     command:
       - /bin/sh
       - -c
@@ -67,7 +67,7 @@
     environment:
       RUST_LOG: info
   vault_1:
-    image: interlayhq/interbtc-clients:vault-parachain-metadata-interlay-testnet-1-16-0
+    image: interlayhq/interbtc-clients:vault-parachain-metadata-interlay-testnet-1-17-0
     command:
       - /bin/sh
       - -c
@@ -85,7 +85,7 @@
       BITCOIN_RPC_PASS: rpcpassword
       RUST_LOG: info
   vault_2:
-    image: 'interlayhq/interbtc-clients:vault-parachain-metadata-interlay-testnet-1-16-0'
+    image: 'interlayhq/interbtc-clients:vault-parachain-metadata-interlay-testnet-1-17-0'
     command:
       - /bin/sh
       - -c
@@ -100,7 +100,7 @@
     environment:
       <<: *client-env
   vault_3:
-    image: 'interlayhq/interbtc-clients:vault-parachain-metadata-interlay-testnet-1-16-0'
+    image: 'interlayhq/interbtc-clients:vault-parachain-metadata-interlay-testnet-1-17-0'
     command:
       - /bin/sh
       - -c
@@ -115,7 +115,7 @@
     environment:
       <<: *client-env
   vault_to_liquidate:
-    image: 'interlayhq/interbtc-clients:vault-parachain-metadata-interlay-testnet-1-16-0'
+    image: 'interlayhq/interbtc-clients:vault-parachain-metadata-interlay-testnet-1-17-0'
     command:
       - /bin/sh
       - -c
@@ -130,7 +130,7 @@
     environment:
       <<: *client-env
   vault_to_ban:
-    image: 'interlayhq/interbtc-clients:vault-parachain-metadata-interlay-testnet-1-16-0'
+    image: 'interlayhq/interbtc-clients:vault-parachain-metadata-interlay-testnet-1-17-0'
     command:
       - /bin/sh
       - -c

--- a/configs/interlay.yml
+++ b/configs/interlay.yml
@@ -1,6 +1,6 @@
 # Relaychain Configuration
 relaychain:
-  image: parity/polkadot:v0.9.18 # the docker image to use
+  image: parity/polkadot:v0.9.26 # the docker image to use
   chain: rococo-local # the chain to use
   runtimeGenesisConfig: # additonal genesis override
     configuration:
@@ -26,7 +26,7 @@ relaychain:
 # Parachain Configuration
 parachains:
 # Config for first parachain
-- image: interlayhq/interbtc:1.18.0
+- image: interlayhq/interbtc:1.19.0
   chain: # this could be a string like `dev` or a config object
     # base: interbtc-parachain # the chain to use
     base: rococo-local-interlay # the chain to use

--- a/configs/kintsugi-services.yml
+++ b/configs/kintsugi-services.yml
@@ -52,7 +52,7 @@
     ports:
       - '3002:3002'
   oracle:
-    image: docker.io/interlayhq/interbtc-clients:oracle-parachain-metadata-kintsugi-testnet-1-17-0
+    image: docker.io/interlayhq/interbtc-clients:oracle-parachain-metadata-kintsugi-testnet-1.17.0
     command:
       - /bin/sh
       - -c
@@ -67,7 +67,7 @@
     environment:
       RUST_LOG: info
   vault_1:
-    image: interlayhq/interbtc-clients:vault-parachain-metadata-kintsugi-testnet-1-17-0
+    image: interlayhq/interbtc-clients:vault-parachain-metadata-kintsugi-testnet-1.17.0
     command:
       - /bin/sh
       - -c
@@ -85,7 +85,7 @@
       BITCOIN_RPC_PASS: rpcpassword
       RUST_LOG: info
   vault_2:
-    image: 'interlayhq/interbtc-clients:vault-parachain-metadata-kintsugi-testnet-1-17-0'
+    image: 'interlayhq/interbtc-clients:vault-parachain-metadata-kintsugi-testnet-1.17.0'
     command:
       - /bin/sh
       - -c
@@ -100,7 +100,7 @@
     environment:
       <<: *client-env
   vault_3:
-    image: 'interlayhq/interbtc-clients:vault-parachain-metadata-kintsugi-testnet-1-17-0'
+    image: 'interlayhq/interbtc-clients:vault-parachain-metadata-kintsugi-testnet-1.17.0'
     command:
       - /bin/sh
       - -c
@@ -115,7 +115,7 @@
     environment:
       <<: *client-env
   vault_to_liquidate:
-    image: 'interlayhq/interbtc-clients:vault-parachain-metadata-kintsugi-testnet-1-17-0'
+    image: 'interlayhq/interbtc-clients:vault-parachain-metadata-kintsugi-testnet-1.17.0'
     command:
       - /bin/sh
       - -c
@@ -130,7 +130,7 @@
     environment:
       <<: *client-env
   vault_to_ban:
-    image: 'interlayhq/interbtc-clients:vault-parachain-metadata-kintsugi-testnet-1-17-0'
+    image: 'interlayhq/interbtc-clients:vault-parachain-metadata-kintsugi-testnet-1.17.0'
     command:
       - /bin/sh
       - -c

--- a/configs/kintsugi-services.yml
+++ b/configs/kintsugi-services.yml
@@ -52,7 +52,7 @@
     ports:
       - '3002:3002'
   oracle:
-    image: docker.io/interlayhq/interbtc-clients:oracle-parachain-metadata-kintsugi-testnet-1-16-0
+    image: docker.io/interlayhq/interbtc-clients:oracle-parachain-metadata-kintsugi-testnet-1-17-0
     command:
       - /bin/sh
       - -c
@@ -67,7 +67,7 @@
     environment:
       RUST_LOG: info
   vault_1:
-    image: interlayhq/interbtc-clients:vault-parachain-metadata-kintsugi-testnet-1-16-0
+    image: interlayhq/interbtc-clients:vault-parachain-metadata-kintsugi-testnet-1-17-0
     command:
       - /bin/sh
       - -c
@@ -85,7 +85,7 @@
       BITCOIN_RPC_PASS: rpcpassword
       RUST_LOG: info
   vault_2:
-    image: 'interlayhq/interbtc-clients:vault-parachain-metadata-kintsugi-testnet-1-16-0'
+    image: 'interlayhq/interbtc-clients:vault-parachain-metadata-kintsugi-testnet-1-17-0'
     command:
       - /bin/sh
       - -c
@@ -100,7 +100,7 @@
     environment:
       <<: *client-env
   vault_3:
-    image: 'interlayhq/interbtc-clients:vault-parachain-metadata-kintsugi-testnet-1-16-0'
+    image: 'interlayhq/interbtc-clients:vault-parachain-metadata-kintsugi-testnet-1-17-0'
     command:
       - /bin/sh
       - -c
@@ -115,7 +115,7 @@
     environment:
       <<: *client-env
   vault_to_liquidate:
-    image: 'interlayhq/interbtc-clients:vault-parachain-metadata-kintsugi-testnet-1-16-0'
+    image: 'interlayhq/interbtc-clients:vault-parachain-metadata-kintsugi-testnet-1-17-0'
     command:
       - /bin/sh
       - -c
@@ -130,7 +130,7 @@
     environment:
       <<: *client-env
   vault_to_ban:
-    image: 'interlayhq/interbtc-clients:vault-parachain-metadata-kintsugi-testnet-1-16-0'
+    image: 'interlayhq/interbtc-clients:vault-parachain-metadata-kintsugi-testnet-1-17-0'
     command:
       - /bin/sh
       - -c

--- a/configs/kintsugi-services.yml
+++ b/configs/kintsugi-services.yml
@@ -57,7 +57,7 @@
       - /bin/sh
       - -c
       - |
-        oracle-parachain-metadata-kintsugi-testnet \
+        /usr/local/bin/oracle \
         --keyring charlie \
         --btc-parachain-url 'ws://parachain-2000-0:9944' \
         --currency-id DOT=230 \
@@ -78,7 +78,7 @@
         # sleep for 30s to wait for bitcoin to create the Charlie wallet
         # and also to ensure that the issue period and redeem period are set
         sleep 30
-        vault-parachain-metadata-kintsugi-testnet --keyfile="keyfile.json" --keyname="vault_1" --auto-register=KSM=10000000000000 --auto-register=KINT=10000000000000 --btc-parachain-url 'ws://parachain-2000-0:9944'
+        /usr/local/bin/vault --keyfile="keyfile.json" --keyname="vault_1" --auto-register=KSM=10000000000000 --auto-register=KINT=10000000000000 --btc-parachain-url 'ws://parachain-2000-0:9944'
     environment: &client-env
       BITCOIN_RPC_URL: http://bitcoind:18443
       BITCOIN_RPC_USER: rpcuser
@@ -96,7 +96,7 @@
         # sleep for 30s to wait for bitcoin to create the Dave wallet
         # and also to ensure that the issue period and redeem period are set
         sleep 30
-        vault-parachain-metadata-kintsugi-testnet --keyfile="keyfile.json" --keyname=vault_2 --auto-register=KSM=10000000000000 --auto-register=KINT=10000000000000 --no-issue-execution --btc-parachain-url 'ws://parachain-2000-0:9944'
+        /usr/local/bin/vault --keyfile="keyfile.json" --keyname=vault_2 --auto-register=KSM=10000000000000 --auto-register=KINT=10000000000000 --no-issue-execution --btc-parachain-url 'ws://parachain-2000-0:9944'
     environment:
       <<: *client-env
   vault_3:
@@ -111,7 +111,7 @@
         # sleep for 30s to wait for bitcoin to create the Eve wallet
         # and also to ensure that the issue period and redeem period are set
         sleep 30
-        vault-parachain-metadata-kintsugi-testnet --keyfile="keyfile.json" --keyname=vault_3 --auto-register=KSM=10000000000000 --auto-register=KINT=10000000000000 --no-issue-execution --btc-parachain-url 'ws://parachain-2000-0:9944'
+        /usr/local/bin/vault --keyfile="keyfile.json" --keyname=vault_3 --auto-register=KSM=10000000000000 --auto-register=KINT=10000000000000 --no-issue-execution --btc-parachain-url 'ws://parachain-2000-0:9944'
     environment:
       <<: *client-env
   vault_to_liquidate:
@@ -126,7 +126,7 @@
         # sleep for 30s to wait for bitcoin to create the Ferdie wallet
         # and also to ensure that the issue period and redeem period are set
         sleep 30
-        vault-parachain-metadata-kintsugi-testnet --keyfile="keyfile.json" --keyname=vault_to_liquidate --auto-register=KSM=10000000000000 --auto-register=KINT=10000000000000 --btc-parachain-url 'ws://parachain-2000-0:9944'
+        /usr/local/bin/vault --keyfile="keyfile.json" --keyname=vault_to_liquidate --auto-register=KSM=10000000000000 --auto-register=KINT=10000000000000 --btc-parachain-url 'ws://parachain-2000-0:9944'
     environment:
       <<: *client-env
   vault_to_ban:
@@ -141,6 +141,6 @@
         # sleep for 30s to wait for bitcoin to create the Ferdie wallet
         # and also to ensure that the issue period and redeem period are set
         sleep 30
-        vault-parachain-metadata-kintsugi-testnet --keyfile="keyfile.json" --keyname=vault_to_ban --auto-register=KSM=10000000000000 --auto-register=KINT=10000000000000 --btc-parachain-url 'ws://parachain-2000-0:9944'
+        /usr/local/bin/vault --keyfile="keyfile.json" --keyname=vault_to_ban --auto-register=KSM=10000000000000 --auto-register=KINT=10000000000000 --btc-parachain-url 'ws://parachain-2000-0:9944'
     environment:
       <<: *client-env

--- a/configs/kintsugi.yml
+++ b/configs/kintsugi.yml
@@ -1,6 +1,6 @@
 # Relaychain Configuration
 relaychain:
-  image: parity/polkadot:v0.9.18 # the docker image to use
+  image: parity/polkadot:v0.9.26 # the docker image to use
   chain: rococo-local # the chain to use
   runtimeGenesisConfig: # additonal genesis override
     configuration:
@@ -26,7 +26,7 @@ relaychain:
 # Parachain Configuration
 parachains:
 # Config for first parachain
-- image: interlayhq/interbtc:1.18.0
+- image: interlayhq/interbtc:1.19.0
   chain: # this could be a string like `dev` or a config object
     base: rococo-local # the chain to use
     collators:


### PR DESCRIPTION
Parachain version: 1.19.0
Client versions: 1.17.0
Polkadot version: 0.9.26