### PR TITLE
Chore: bump parachain version to 1.21.1

### DIFF
--- a/configs/interlay.yml
+++ b/configs/interlay.yml
@@ -26,7 +26,7 @@ relaychain:
 # Parachain Configuration
 parachains:
 # Config for first parachain
-- image: interlayhq/interbtc:1.21.0
+- image: interlayhq/interbtc:1.21.1
   chain: # this could be a string like `dev` or a config object
     # base: interbtc-parachain # the chain to use
     base: rococo-local-interlay # the chain to use

--- a/configs/kintsugi.yml
+++ b/configs/kintsugi.yml
@@ -26,7 +26,7 @@ relaychain:
 # Parachain Configuration
 parachains:
 # Config for first parachain
-- image: interlayhq/interbtc:1.21.0
+- image: interlayhq/interbtc:1.21.1
   chain: # this could be a string like `dev` or a config object
     base: rococo-local # the chain to use
     collators:


### PR DESCRIPTION
Update parachain version from `1.21.0` to `1.21.1`
Clients stay at version `1.19.0`